### PR TITLE
Fix global states storage getter issue

### DIFF
--- a/.changeset/angry-dots-ring.md
+++ b/.changeset/angry-dots-ring.md
@@ -1,0 +1,5 @@
+---
+"@realmorg/realm": patch
+---
+
+Update fix global states storage getter issue

--- a/packages/realm/src/libs/RealmState.class.ts
+++ b/packages/realm/src/libs/RealmState.class.ts
@@ -1,5 +1,5 @@
 import { MixedDataType } from "../constants/data";
-import { JSONSafeParse, JSONSafeStringify } from "../utils/json";
+import { JSONSafeStringify, JSONparse, JSONstringify } from "../utils/json";
 import {
   addSet,
   createMap,
@@ -60,7 +60,7 @@ export class RealmState {
   get<T>(name?: string, storage?: StateStorage) {
     if (storage !== StateStorage.MEMORY) {
       const value = window?.[storage]?.getItem(name);
-      if (value) return JSONSafeParse(value);
+      if (value !== undefined) return JSONparse(JSONstringify(value));
     }
     return getMap(this.#states, name) as T;
   }


### PR DESCRIPTION
This PR will fix `getItem` storage by using native JSON stringify and parser