### PR TITLE
Fix update global states update slot bind

### DIFF
--- a/.changeset/serious-points-divide.md
+++ b/.changeset/serious-points-divide.md
@@ -1,0 +1,5 @@
+---
+"@realmorg/realm": patch
+---
+
+Update global states flow

--- a/packages/realm/src/utils/element.ts
+++ b/packages/realm/src/utils/element.ts
@@ -321,13 +321,16 @@ const updateSlot = (
         [`${DATA_PREFIX}${dataType}`, slotAttrName],
       ];
 
-  const nodes = element.$qsAll<HTMLSlotElement>(
-    selector,
-    attrs,
-    isGlobalUpdate ? doc : undefined
-  );
+  const nodes = createArray<HTMLSlotElement>([
+    ...element.$qsAll<HTMLSlotElement>(selector, attrs),
+    ...element.$qsAll<HTMLSlotElement>(
+      selector,
+      attrs,
+      isGlobalUpdate ? doc : undefined
+    ),
+  ]);
 
-  forEachNode(nodes, (slot) => {
+  forEach(nodes, (slot) => {
     if (!slot) return;
     if (slotAttrType === ElementDataTypes.HTML) {
       element._html(slotValue, slot);


### PR DESCRIPTION
This PR will updates:

* global slot `querySelector` list now detect global slot directly from `document` and owner element