### PR TITLE
Fix update custom css selector regex

### DIFF
--- a/.changeset/brown-llamas-fry.md
+++ b/.changeset/brown-llamas-fry.md
@@ -1,0 +1,5 @@
+---
+"@realmorg/realm": patch
+---
+
+Update fix css selector regex support alphanumeric and - (dash), . (dot), and \_ (underscore)

--- a/packages/realm/src/constants/regx.ts
+++ b/packages/realm/src/constants/regx.ts
@@ -3,6 +3,6 @@ export const UPPERCASE_ALPHABET_REGEX = /([A-Z])+/g;
 export const SPECIAL_CHARS_REGEX = /(?=[A-Z])|[.\-\s_]/;
 
 export const CSS_CUSTOM_SELECTOR_REGEX =
-  /:host\(\[\\([#@]\w+?)\](\[(global)\])?(\[(eq|neq|gt|gte|lt|lte|contains)="(\w+?)"\])?\)/g;
+  /:host\(\[\\([#@][a-zA-Z0-9-_.]+?)\](\[(global)\])?(\[(eq|neq|gt|gte|lt|lte|contains)="(\w+?)"\])?\)/g;
 
 export const DOT_NOTATION_REGEX = /[$|#|@|!]([.]?(?:\w+[.-])*\w+)/gm;

--- a/packages/realm/src/utils/cssom.ts
+++ b/packages/realm/src/utils/cssom.ts
@@ -123,7 +123,6 @@ export const _renderStyle =
         rule,
         strReplace(selector, CSS_CUSTOM_SELECTOR_REGEX, HOST_SELECTOR)
       );
-      // CSSText(currentRule, EMPTY_STRING);
 
       // @note: add --style css var to rule
       _CSSvar(


### PR DESCRIPTION
This PR will update css selector regex that supports alphanumeric and `-` (dash), `.` (dot), and `_` (underscore)