### PR TITLE
Fix error css selector and early return

### DIFF
--- a/.changeset/small-ways-whisper.md
+++ b/.changeset/small-ways-whisper.md
@@ -1,0 +1,6 @@
+---
+"@realmorg/realm": patch
+---
+
+- Update fix error css selector regex on Safari
+- Update fix early return in attr bind reducer

--- a/packages/realm/src/constants/regx.ts
+++ b/packages/realm/src/constants/regx.ts
@@ -2,7 +2,10 @@ export const UPPERCASE_ALPHABET_REGEX = /([A-Z])+/g;
 
 export const SPECIAL_CHARS_REGEX = /(?=[A-Z])|[.\-\s_]/;
 
-export const CSS_CUSTOM_SELECTOR_REGEX =
-  /:host\(\[\\([#@][a-zA-Z0-9-_.]+?)\](\[(global)\])?(\[(eq|neq|gt|gte|lt|lte|contains)="(\w+?)"\])?\)/g;
+const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
+export const CSS_CUSTOM_SELECTOR_REGEX = isSafari
+  ? /:host\(\[([#@][a-zA-Z0-9-_.]+?)\](\[(global)\])?(\[(eq|neq|gt|gte|lt|lte|contains)=\"(\w+?)\"\])?\)/g
+  : /:host\(\[\\([#@][a-zA-Z0-9-_.]+?)\](\[(global)\])?(\[(eq|neq|gt|gte|lt|lte|contains)="(\w+?)"\])?\)/g;
 
 export const DOT_NOTATION_REGEX = /[$|#|@|!]([.]?(?:\w+[.-])*\w+)/gm;

--- a/packages/realm/src/utils/element.ts
+++ b/packages/realm/src/utils/element.ts
@@ -483,15 +483,15 @@ export const getElementAttrBindings = (element: RealmElement) =>
         arrayReduce<Attr, Array<Set<BindingAttrValue>>>(
           element.$attrs(node),
           (acc, attr) => {
+            const hasBindAttr = strStartWith($attrName(attr), BIND_ATTR_PREFIX);
+            const hasAttr = element.$hasAttr($attrName(attr), node);
+            if (hasAttr && !hasBindAttr) return acc;
+
             const [attrName, global] = strSplit(
               $attrName(attr),
               ATTR_SEPARATOR
             );
             const isGlobal = global === RealmAttributeNames.GLOBAL;
-
-            const hasBindAttr = strStartWith(attrName, BIND_ATTR_PREFIX);
-            const hasAttr = element.$hasAttr(attrName, node);
-            if (hasAttr && !hasBindAttr) return acc;
 
             const attrValue = $attrValue(attr);
             const slicedAttrName = strSlice(attrName);


### PR DESCRIPTION
This PR will fixes:

* Update fix error css selector regex on Safari
* Update fix early return in attr bind reducer