### PR TITLE
Fix several errors when build

### DIFF
--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -8,6 +8,7 @@ import critters from "astro-critters";
 
 // https://astro.build/config
 export default defineConfig({
+  site: "https://realm.codes",
   integrations: [
     mdx(),
     partytown(),

--- a/apps/web/public/elements/basic-counter.html
+++ b/apps/web/public/elements/basic-counter.html
@@ -9,7 +9,7 @@
 
   <template>
     <button ref="AddCountButton">
-      Add count <slot name="#count"></slot>
+      Add count&nbsp;<slot name="#count"></slot>
     </button>
   </template>
 </custom-element>


### PR DESCRIPTION
This PR will fixes these errors:

* Add `basic-counter` element missing unicode space caused by minifier
* Add `site` field in astro config to avoid render `http://localhost:3000` when build